### PR TITLE
Publishing build to GitHub Packages

### DIFF
--- a/.github/workflows/ts-java-package-publish.yml
+++ b/.github/workflows/ts-java-package-publish.yml
@@ -1,0 +1,25 @@
+name: Publish Java Package
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java version 11 (for building custom hibernate)
+        uses: actions/setup-java@v4
+        with:
+          java-version: "11"
+          distribution: "zulu"
+
+      - name: Publish package
+        run: |
+          ./gradlew hibernate-core:clean
+          ./gradlew hibernate-core:publish -Pgithub.user=${{ github.actor }} -Pgithub.token=${{ secrets.GITHUB_TOKEN }}

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -273,6 +273,25 @@ tasks.named( "javadoc", Javadoc ) {
     }
 }
 
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/TestsigmaInc/hibernate-orm")
+            credentials {
+                username = project.findProperty("github.user")
+                password = project.findProperty("github.token")
+            }
+        }
+    }
+}
+
 tasks.sourcesJar.dependsOn ':hibernate-core:generateGraphParser'
 tasks.sourcesJar.dependsOn ':hibernate-core:generateHqlParser'
 tasks.sourcesJar.dependsOn ':hibernate-core:generateSqlScriptParser'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - hibernate-core is now published as a Maven package to GitHub Packages for easier consumption via Maven/Gradle.

- Chores
  - Added an automated CI workflow to build and publish the Java package on demand.
  - Improved source JAR generation to include all relevant sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->